### PR TITLE
Typo - decoding mode string (squence -> sequence)

### DIFF
--- a/notebooks/asmc.ipynb
+++ b/notebooks/asmc.ipynb
@@ -41,7 +41,7 @@
     "    out_file_root=\"\",\n",
     "    jobs=1,                               # Number of jobs being done in total\n",
     "    job_ind=1,                            # Job index (0, ..., jobs)\n",
-    "    decoding_mode_string=\"array\",         # One of {\"squence\", \"array\"}\n",
+    "    decoding_mode_string=\"array\",         # One of {\"sequence\", \"array\"}\n",
     "    decoding_sequence=False,\n",
     "    using_CSFS=True,                      # Whether to use CSFS\n",
     "    compress=False,                       # Compress emission to binary (no CSFS)\n",


### PR DESCRIPTION
@fcooper8472 Feel free merge in directly as I think this is just a typo that I didn't want to commit directly to the main branch. 